### PR TITLE
fix: :adhesive_bandage: Fix project button link redirecting to 404 page

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -139,7 +139,11 @@ const About = () => {
           <p className="md:text-2xl my-10 text-bensongrey w-11/12">
             Web Apps, freelance projects, personal projects and experiments
           </p>
-          <Button type="internal" to="/projects">
+          <Button
+            type="external"
+            href="https://github.com/stbensonimoh"
+            target="_blank"
+          >
             See my work &nbsp;
             <MdArrowForward />
           </Button>


### PR DESCRIPTION
Since the project page is not ready. Make the project button on the about page temporary link to my GitHub profile.

Fixes: #31 