### PR TITLE
feat: add dynamic sitemap generation and update author summary

### DIFF
--- a/siteMetadata.ts
+++ b/siteMetadata.ts
@@ -2,7 +2,7 @@ const siteMetadata = {
   title: `Benson Imoh,ST`,
   author: {
     name: `Benson Imoh,ST`,
-    summary: `Software Engineer | Experience Designer(xD) | OSS Enthusiast. Passionate about blending engineering and design, to creatively and efficiently solve problems.`,
+    summary: `Software Engineer | DevOps Enthusiast | OSS Advocate. Passionate about blending engineering and design, to creatively and efficiently solve problems.`,
     image: `https://res.cloudinary.com/stbensonimoh/image/upload/v1692398633/sq_xmnmhb.jpg`,
   },
   description: `Software Engineer | Experience Designer(xD) | OSS Enthusiast`,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,56 @@
+import { MetadataRoute } from "next";
+import { getAllPosts } from "@/lib/posts";
+import siteMetadata from "../../siteMetadata";
+
+const sitemap = (): MetadataRoute.Sitemap => {
+  const { siteUrl } = siteMetadata;
+
+  // Get static routes
+  const staticRoutes = [
+    {
+      url: siteUrl,
+      lastModified: new Date().toISOString(),
+      changeFrequency: "daily" as const,
+      priority: 1,
+    },
+    {
+      url: `${siteUrl}about`, // Assuming your about page is at /about
+      lastModified: new Date().toISOString(),
+      changeFrequency: "monthly" as const,
+      priority: 0.8,
+    },
+    {
+      url: `${siteUrl}contact`, // Assuming your contact page is at /contact
+      lastModified: new Date().toISOString(),
+      changeFrequency: "yearly" as const,
+      priority: 0.5,
+    },
+    {
+      url: `${siteUrl}blog`, // Assuming your blog listing page is at /blog
+      lastModified: new Date().toISOString(),
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    },
+  ];
+
+  // Get dynamic routes (blog posts)
+  const posts = getAllPosts();
+  const blogPostRoutes = posts.map((post) => {
+    // Assuming your frontmatter contains a 'date' field for the last modification
+    // If not, you might want to use a default date or modify getAllPosts
+    const lastModified = post.frontmatter.date
+      ? new Date(post.frontmatter.date).toISOString()
+      : new Date().toISOString();
+
+    return {
+      url: `${siteUrl}blog/${post.slug}`,
+      lastModified,
+      changeFrequency: "weekly" as const,
+      priority: 0.7,
+    };
+  });
+
+  return [...staticRoutes, ...blogPostRoutes];
+};
+
+export default sitemap;


### PR DESCRIPTION
# Description

- Introduced `sitemap.ts` to generate a sitemap with static and dynamic blog routes.
- Updated author summary in `siteMetadata.ts` to reflect "DevOps Enthusiast" and "OSS Advocate" roles.


Fixes #64 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] visit the `siteURL/sitemap.xml`
- [x] It should return an xml file

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes