### PR TITLE
chore(siteMetadata.ts): Change the siteMetadata to reflect my DevOps passions

### DIFF
--- a/siteMetadata.ts
+++ b/siteMetadata.ts
@@ -5,7 +5,7 @@ const siteMetadata = {
     summary: `Software Engineer | DevOps Enthusiast | OSS Advocate. Passionate about blending engineering and design, to creatively and efficiently solve problems.`,
     image: `https://res.cloudinary.com/stbensonimoh/image/upload/v1692398633/sq_xmnmhb.jpg`,
   },
-  description: `Software Engineer | Experience Designer(xD) | OSS Enthusiast`,
+  description: `Software Engineer | DevOps Enthusiast | OSS Advocate`,
   siteUrl: `https://stbensonimoh.com/`,
   social: {
     twitter: `stbensonimoh`,


### PR DESCRIPTION
This pull request includes a minor update to the `siteMetadata.ts` file, specifically refining the `description` field to better align with the updated professional focus.

* [`siteMetadata.ts`](diffhunk://#diff-675c57d8b446b35d308b9cc79bbaeb67b7b673f6d00ed85f064a300a19c35cd8L8-R8): Updated the `description` field to replace "Experience Designer(xD)" with "DevOps Enthusiast" and "OSS Enthusiast" with "OSS Advocate" for a more accurate representation of the author's expertise and interests.