### PR TITLE
feat: add /uses page with tech stack manifest

### DIFF
--- a/src/app/uses/page.tsx
+++ b/src/app/uses/page.tsx
@@ -1,0 +1,174 @@
+import { Metadata } from "next";
+import { roboto } from "@/app/fonts";
+import PageTracker from "@/app/components/PageTracker";
+import { 
+  FiMonitor, 
+  FiCode, 
+  FiTerminal,
+  FiExternalLink,
+  FiCalendar
+} from "react-icons/fi";
+import usesData from "@/data/uses.json";
+
+export const metadata: Metadata = {
+  title: "Uses - Benson Imoh,ST",
+  description: "A list of hardware, software, and development tools I use for software engineering, DevOps, and open source advocacy.",
+  openGraph: {
+    url: "https://stbensonimoh.com/uses",
+    title: "Uses - Benson Imoh,ST",
+    description: "A list of hardware, software, and development tools I use for software engineering, DevOps, and open source advocacy.",
+    images: [
+      {
+        url: "https://res.cloudinary.com/stbensonimoh/image/upload/v1735318948/stbensonimoh_logo.png",
+        width: 1500,
+        height: 1500,
+        alt: "Benson Imoh,ST",
+      },
+    ],
+    siteName: "Benson Imoh,ST",
+  },
+  twitter: {
+    creator: "@stbensonimoh",
+    card: "summary_large_image",
+    title: "Uses - Benson Imoh,ST",
+    description: "A list of hardware, software, and development tools I use for software engineering, DevOps, and open source advocacy.",
+    images: {
+      url: "https://res.cloudinary.com/stbensonimoh/image/upload/v1735318948/stbensonimoh_logo.png",
+      alt: "Benson Imoh, ST's Logo",
+    },
+  },
+};
+
+const iconMap: Record<string, React.ComponentType<{ className?: string }>> = {
+  Monitor: FiMonitor,
+  Code: FiCode,
+  Terminal: FiTerminal,
+};
+
+interface UsesItem {
+  name: string;
+  description: string;
+  url: string;
+}
+
+interface Category {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  items: UsesItem[];
+}
+
+export default function Uses() {
+  const categories: Category[] = usesData.categories;
+  const lastUpdated = usesData.lastUpdated;
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen">
+      <PageTracker pageType="uses" />
+      
+      {/* Hero Section */}
+      <section className="flex flex-col items-center justify-center pt-32 pb-16 md:pt-40 md:pb-24 px-6 bg-surface">
+        <div className="text-center max-w-4xl">
+          <h1 className={`${roboto.className} text-4xl md:text-5xl lg:text-6xl font-medium text-foreground mb-6`}>
+            My Setup<span className="text-primary">.</span>
+          </h1>
+          <p className="text-lg md:text-xl text-secondary max-w-2xl mx-auto leading-relaxed">
+            A comprehensive list of hardware, software, and development tools I use daily for building software, managing infrastructure, and contributing to open source.
+          </p>
+          <div className="flex items-center justify-center mt-8 text-secondary">
+            <FiCalendar className="w-4 h-4 mr-2" />
+            <span className="text-sm">
+              Last updated: {formatDate(lastUpdated)}
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/* Categories Grid */}
+      <section className="flex-grow py-16 md:py-24 px-6 bg-background">
+        <div className="max-w-7xl mx-auto">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 lg:gap-12">
+            {categories.map((category) => {
+              const IconComponent = iconMap[category.icon];
+              
+              return (
+                <div 
+                  key={category.id}
+                  className="flex flex-col bg-surface rounded-lg p-6 md:p-8 transition-transform duration-300 hover:scale-[1.02]"
+                >
+                  {/* Category Header */}
+                  <div className="flex items-center mb-6">
+                    <div className="flex items-center justify-center w-12 h-12 rounded-lg bg-primary/10 text-primary mr-4">
+                      {IconComponent && <IconComponent className="w-6 h-6" />}
+                    </div>
+                    <div>
+                      <h2 className={`${roboto.className} text-2xl font-medium text-foreground`}>
+                        {category.name}
+                      </h2>
+                      <p className="text-sm text-secondary mt-1">
+                        {category.description}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Items List */}
+                  <ul className="space-y-4 flex-grow">
+                    {category.items.map((item, index) => (
+                      <li key={index} className="group">
+                        <a
+                          href={item.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-start p-3 rounded-md transition-colors duration-200 hover:bg-background"
+                        >
+                          <div className="flex-grow">
+                            <h3 className="font-medium text-foreground group-hover:text-primary transition-colors duration-200 flex items-center">
+                              {item.name}
+                              <FiExternalLink className="w-3 h-3 ml-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
+                            </h3>
+                            <p className="text-sm text-secondary mt-1 leading-relaxed">
+                              {item.description}
+                            </p>
+                          </div>
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* Footer Note */}
+      <section className="py-12 px-6 bg-surface">
+        <div className="max-w-3xl mx-auto text-center">
+          <p className="text-secondary text-sm">
+            Some links above may be affiliate links. I only recommend tools I genuinely use and trust. 
+            This page was inspired by the{" "}
+            <a 
+              href="https://uses.tech/" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              /uses
+            </a>
+            {" "}movement.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/data/uses.json
+++ b/src/data/uses.json
@@ -1,0 +1,149 @@
+{
+  "lastUpdated": "2026-02-16",
+  "categories": [
+    {
+      "id": "hardware",
+      "name": "Hardware",
+      "description": "The physical tools that power my workflow",
+      "icon": "Monitor",
+      "items": [
+        {
+          "name": "MacBook Pro 16\" (M3 Max)",
+          "description": "My primary development machine with 36GB RAM",
+          "url": "https://www.apple.com/macbook-pro/"
+        },
+        {
+          "name": "Dell UltraSharp U2723QE",
+          "description": "27\" 4K USB-C monitor for extended screen real estate",
+          "url": "https://www.dell.com/en-us/shop/dell-ultrasharp-27-4k-usb-c-hub-monitor-u2723qe/apd/210-bdpf/monitors-monitor-accessories"
+        },
+        {
+          "name": "Keychron K2 Mechanical Keyboard",
+          "description": "Wireless mechanical keyboard with red switches",
+          "url": "https://www.keychron.com/products/keychron-k2-wireless-mechanical-keyboard"
+        },
+        {
+          "name": "Logitech MX Master 3S",
+          "description": "Ergonomic wireless mouse for productivity",
+          "url": "https://www.logitech.com/en-us/products/mice/mx-master-3s.html"
+        },
+        {
+          "name": "Sony WH-1000XM5",
+          "description": "Noise-canceling headphones for deep focus",
+          "url": "https://electronics.sony.com/headphones/headband/p/wh1000xm5"
+        },
+        {
+          "name": "Standing Desk",
+          "description": "Adjustable desk for alternating between sitting and standing",
+          "url": "https://www.autonomous.ai/standing-desks"
+        }
+      ]
+    },
+    {
+      "id": "software",
+      "name": "Software",
+      "description": "Applications that keep me productive",
+      "icon": "Code",
+      "items": [
+        {
+          "name": "VS Code",
+          "description": "Primary code editor with custom extensions",
+          "url": "https://code.visualstudio.com/"
+        },
+        {
+          "name": "Cursor",
+          "description": "AI-powered code editor for rapid development",
+          "url": "https://cursor.sh/"
+        },
+        {
+          "name": "iTerm2",
+          "description": "Terminal emulator with custom configurations",
+          "url": "https://iterm2.com/"
+        },
+        {
+          "name": "Notion",
+          "description": "All-in-one workspace for notes and documentation",
+          "url": "https://www.notion.so/"
+        },
+        {
+          "name": "Figma",
+          "description": "Design tool for UI/UX prototyping",
+          "url": "https://www.figma.com/"
+        },
+        {
+          "name": "Obsidian",
+          "description": "Knowledge base and note-taking in Markdown",
+          "url": "https://obsidian.md/"
+        },
+        {
+          "name": "Raycast",
+          "description": "Productivity launcher with custom workflows",
+          "url": "https://www.raycast.com/"
+        },
+        {
+          "name": "1Password",
+          "description": "Password manager for secure credential storage",
+          "url": "https://1password.com/"
+        }
+      ]
+    },
+    {
+      "id": "dev-tools",
+      "name": "Dev Tools",
+      "description": "Technologies and frameworks I work with",
+      "icon": "Terminal",
+      "items": [
+        {
+          "name": "Next.js",
+          "description": "React framework for production-grade applications",
+          "url": "https://nextjs.org/"
+        },
+        {
+          "name": "TypeScript",
+          "description": "Typed JavaScript for better developer experience",
+          "url": "https://www.typescriptlang.org/"
+        },
+        {
+          "name": "Tailwind CSS",
+          "description": "Utility-first CSS framework for rapid styling",
+          "url": "https://tailwindcss.com/"
+        },
+        {
+          "name": "React",
+          "description": "JavaScript library for building user interfaces",
+          "url": "https://react.dev/"
+        },
+        {
+          "name": "Node.js",
+          "description": "JavaScript runtime for server-side development",
+          "url": "https://nodejs.org/"
+        },
+        {
+          "name": "Docker",
+          "description": "Containerization platform for consistent environments",
+          "url": "https://www.docker.com/"
+        },
+        {
+          "name": "Git",
+          "description": "Version control system for tracking code changes",
+          "url": "https://git-scm.com/"
+        },
+        {
+          "name": "GitHub Actions",
+          "description": "CI/CD automation for testing and deployment",
+          "url": "https://github.com/features/actions"
+        },
+        {
+          "name": "PostgreSQL",
+          "description": "Relational database for structured data storage",
+          "url": "https://www.postgresql.org/"
+        },
+        {
+          "name": "Vercel",
+          "description": "Platform for deploying and hosting web applications",
+          "url": "https://vercel.com/"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Implements Issue #97 - a /uses page showcasing hardware, software, and development tools.

## Changes
- **data/uses.json**: Categorized tools data (Hardware, Software, Dev Tools)
- **src/app/uses/page.tsx**: Responsive grid layout with Tailwind CSS

## Features
- Responsive 3-column grid layout (stacks on mobile)
- SEO metadata (OpenGraph + Twitter cards)
- Last Updated timestamp
- All external links with `rel="noopener noreferrer"`
- Hover effects and consistent styling

## Preview
Vercel preview deployment should be available shortly.

Closes #97