### PR TITLE
chore: remove stale Vercel entries from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,6 @@ yarn.lock
 # env files (can opt-in for commiting if needed)
 .env*
 
-# vercel
-.vercel
-
 # cloudflare
 .wrangler/
 .open-next/


### PR DESCRIPTION
## Why

The `.gitignore` contained a `# vercel` section with a `.vercel` entry that was left behind after the project migrated to Cloudflare Workers via OpenNext. While harmless, stale references erode clarity about the project's actual deployment target and create noise for contributors trying to understand the stack.

This is a follow-up to PR #129, which removed `scripts/vercel-ignore.sh` and updated the main documentation. The gitignore entries were missed in that pass.

## What Changed

- `.gitignore`: Removed the `# vercel` comment block and `.vercel` entry (2 lines)
- The adjacent Cloudflare-specific entries (`.wrangler/`, `.open-next/`) are unaffected

## Testing

- `grep -n "vercel\|Vercel" .gitignore` returns zero results
- `.wrangler/` and `.open-next/` entries remain intact
- No functional code changes; no tests required for gitignore-only changes

## Checklist

- [x] Self-review completed
- [x] Related issue linked (closes #120)

## Labels

- `chore` — maintenance with no production code impact
- `scope:infra` — repository configuration cleanup
- `priority:medium` — non-urgent but completes the migration