### PR TITLE
ci: add validate-deployment-path job for OpenNext/Cloudflare build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,29 @@ jobs:
 
       - name: Test
         run: bun run test
+
+  # Validates the OpenNext/Cloudflare Workers build packaging path used by production deployments.
+  # Runs only on push to main (not on pull requests) to keep PR feedback cycles fast.
+  validate-deployment-path:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    needs: lint-and-test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate posts data
+        run: bun run scripts/generate-posts-data.ts
+
+      - name: Build for Cloudflare Workers
+        run: opennextjs-cloudflare build
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/TECHNICAL_SPEC.md
+++ b/TECHNICAL_SPEC.md
@@ -478,16 +478,32 @@ bun test --coverage  # Generate coverage report
 
 Triggered on: push to `main`, pull requests targeting `main`.
 
+#### Job: `lint-and-test`
+
 Steps (in order):
 
 1. Checkout repository
 2. Setup Bun
 3. `bun install --frozen-lockfile`
 4. `bun run lint`
-5. `bun run test`
+5. `bun run build`
+6. `bun run test`
 
-- The CI workflow MUST NOT merge if linting or tests fail.
-- A `bun run build` step SHOULD be added once build-time validation is required in CI.
+The CI workflow MUST NOT merge if linting or tests fail.
+
+#### Job: `validate-deployment-path`
+
+Validates the OpenNext/Cloudflare Workers build packaging path used by production deployments. Runs only on `push` to `main`, not on pull requests, to keep PR feedback cycles fast.
+
+Steps (in order):
+
+1. Checkout repository
+2. Setup Bun
+3. `bun install --frozen-lockfile`
+4. `bun run generate-posts-data`
+5. `opennextjs-cloudflare build`
+
+Requires `CLOUDFLARE_API_TOKEN` as a GitHub Actions secret (wired as the `CLOUDFLARE_API_TOKEN` environment variable). The build step does not deploy; it only validates that the packaging stage succeeds.
 
 ### 15.2 Release Workflow (`.github/workflows/release-please.yml`)
 


### PR DESCRIPTION
## Why

The CI pipeline validated `bun run build` but not the OpenNext/Cloudflare Workers packaging path. A repository can pass the app build while still failing at the packaging stage, which is the stage that determines whether the site actually deploys to Cloudflare Workers.

This means contributors could merge code that appears to work in CI but fails at deploy time. Closing that gap improves confidence that CI passing means the site will actually deploy.

## What Changed

- `.github/workflows/ci.yml`: Added `validate-deployment-path` job that runs `opennextjs-cloudflare build` on push to `main`. The job injects `CLOUDFLARE_API_TOKEN` from GitHub Secrets. It runs after `lint-and-test` completes and is gated to `push` events only, not PRs, to keep PR feedback cycles fast.
- `TECHNICAL_SPEC.md`: Updated §15.1 to reflect current CI state (`bun run build` already existed in CI, now documented) and to document the new job, its trigger conditions, and its secret requirement.

## Testing

- `bun run lint`: Pass (8 pre-existing warnings about `<img>` tags, unrelated to this change)
- `bun run test`: 5 pass, 0 fail
- `bun run build`: Success
- YAML syntax validated by reading back the workflow file

## Checklist

- [x] Self-review completed
- [x] Documentation updated (TECHNICAL_SPEC.md)
- [x] No breaking changes
- [x] Related issue linked (closes #119)

## Labels

- `enhancement` — adds new CI capability
- `scope:ci` — CI pipeline changes
- `scope:infra` — infrastructure configuration
- `priority:high` — closes a gap in the deployment validation chain