### PR TITLE
fix(ci): use bun run to execute opennextjs-cloudflare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,9 @@ jobs:
         run: bun run test
 
   # Validates the OpenNext/Cloudflare Workers build packaging path used by production deployments.
-  # Runs only on push to main (not on pull requests) to keep PR feedback cycles fast.
+  # Runs on all push events during testing. Will be restricted to main after verification.
   validate-deployment-path:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     needs: lint-and-test
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,6 @@ jobs:
         run: bun run scripts/generate-posts-data.ts
 
       - name: Build for Cloudflare Workers
-        run: opennextjs-cloudflare build
+        run: bun run opennextjs-cloudflare build
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -33,9 +34,10 @@ jobs:
         run: bun run test
 
   # Validates the OpenNext/Cloudflare Workers build packaging path used by production deployments.
-  # Runs on all push events during testing. Will be restricted to main after verification.
+  # Runs only on push to main (not on pull requests) to keep PR feedback cycles fast.
   validate-deployment-path:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     needs: lint-and-test
 
     steps:


### PR DESCRIPTION
## Why

The `validate-deployment-path` job failed on first merge to main because `opennextjs-cloudflare build` was invoked directly, but the binary is not in PATH. Using `bun run opennextjs-cloudflare build` ensures `node_modules/.bin` is included in PATH.

## What Changed

- `.github/workflows/ci.yml`: Changed `opennextjs-cloudflare build` to `bun run opennextjs-cloudflare build`

## Testing

- `bun run build` passes locally
- No code changes beyond one CLI invocation fix

## Checklist

- [x] Self-review completed
- [x] No breaking changes
- [x] Related issue linked (closes #119)

## Labels

- `bugfix` — fixes CI failure
- `scope:ci` — CI pipeline changes
- `priority:high` — blocks deployment validation