### PR TITLE
fix: upgrade @opennextjs/cloudflare to 1.19.6 for Next.js 16.2 compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "sweetalert2": "^11.6.13",
       },
       "devDependencies": {
-        "@opennextjs/cloudflare": "^1.17.1",
+        "@opennextjs/cloudflare": "^1.19.6",
         "@types/markdown-it": "^14.1.2",
         "@types/node": "^20",
         "@types/react": "19.2.7",
@@ -403,9 +403,9 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
-    "@opennextjs/aws": ["@opennextjs/aws@3.9.16", "", { "dependencies": { "@ast-grep/napi": "^0.40.5", "@aws-sdk/client-cloudfront": "3.984.0", "@aws-sdk/client-dynamodb": "3.984.0", "@aws-sdk/client-lambda": "3.984.0", "@aws-sdk/client-s3": "3.984.0", "@aws-sdk/client-sqs": "3.984.0", "@node-minify/core": "^8.0.6", "@node-minify/terser": "^8.0.6", "@tsconfig/node18": "^1.0.3", "aws4fetch": "^1.0.20", "chalk": "^5.6.2", "cookie": "^1.0.2", "esbuild": "0.25.4", "express": "^5.1.0", "path-to-regexp": "^6.3.0", "urlpattern-polyfill": "^10.1.0", "yaml": "^2.8.1" }, "peerDependencies": { "next": "~15.0.8 || ~15.1.12 || ~15.2.9 || ~15.3.9 || ~15.4.11 || ~15.5.10 || ~16.0.11 || ^16.1.5" }, "bin": { "open-next": "dist/index.js" } }, "sha512-jQQStCysIllNCPqz5W2KSguXpr+ETlOcD8SyNu+h9zwpRVYk4uEPQge+ErG3avI5xsT8vKA7EGLYG59dhj/B6Q=="],
+    "@opennextjs/aws": ["@opennextjs/aws@3.10.4", "", { "dependencies": { "@ast-grep/napi": "^0.40.5", "@aws-sdk/client-cloudfront": "3.984.0", "@aws-sdk/client-dynamodb": "3.984.0", "@aws-sdk/client-lambda": "3.984.0", "@aws-sdk/client-s3": "3.984.0", "@aws-sdk/client-sqs": "3.984.0", "@node-minify/core": "^8.0.6", "@node-minify/terser": "^8.0.6", "@tsconfig/node18": "^1.0.3", "aws4fetch": "^1.0.20", "chalk": "^5.6.2", "cookie": "^1.0.2", "esbuild": "0.25.4", "express": "^5.1.0", "path-to-regexp": "^6.3.0", "urlpattern-polyfill": "^10.1.0", "yaml": "^2.8.1" }, "peerDependencies": { "next": ">=15.5.15 <16 || >=16.2.3" }, "bin": { "open-next": "dist/index.js" } }, "sha512-xVmWHGdptJgVhQivuoeAYqsWpIgGoDEeZJC6AYMgvQYisDicGuS7gh10Z8MEmrgsJxNGdZ0arCCDieGxM88afw=="],
 
-    "@opennextjs/cloudflare": ["@opennextjs/cloudflare@1.17.1", "", { "dependencies": { "@ast-grep/napi": "^0.40.5", "@dotenvx/dotenvx": "1.31.0", "@opennextjs/aws": "3.9.16", "cloudflare": "^4.4.1", "comment-json": "^4.5.1", "enquirer": "^2.4.1", "glob": "^12.0.0", "ts-tqdm": "^0.8.6", "yargs": "^18.0.0" }, "peerDependencies": { "next": "~15.0.8 || ~15.1.12 || ~15.2.9 || ~15.3.9 || ~15.4.11 || ~15.5.10 || ~16.0.11 || ^16.1.5", "wrangler": "^4.65.0" }, "bin": { "opennextjs-cloudflare": "dist/cli/index.js" } }, "sha512-TtmjhXUEpSbnb9kgr7IQtmlQugOeX0cHiLc/e6NYAnmqQVro3yN49WvzaclSGFZod/lJFW7pOJ0NGT6JpqypAw=="],
+    "@opennextjs/cloudflare": ["@opennextjs/cloudflare@1.19.6", "", { "dependencies": { "@ast-grep/napi": "^0.40.5", "@dotenvx/dotenvx": "1.31.0", "@opennextjs/aws": "3.10.4", "ci-info": "^4.2.0", "cloudflare": "^4.4.1", "comment-json": "^4.5.1", "enquirer": "^2.4.1", "glob": "^12.0.0", "ts-tqdm": "^0.8.6", "yargs": "^18.0.0" }, "peerDependencies": { "next": ">=15.5.15 <16 || >=16.2.3", "wrangler": "^4.86.0" }, "bin": { "opennextjs-cloudflare": "dist/cli/index.js" } }, "sha512-2Qd0IbcqPdsjsiaFrmACxuJHR8Pxm1JrUJIn/tFoTu+HsfFR7W921NZI50KQ5bulqg1e//Lb5TonwQlEgmSBGw=="],
 
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
@@ -750,6 +750,8 @@
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
+    "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "sweetalert2": "^11.6.13"
   },
   "devDependencies": {
-    "@opennextjs/cloudflare": "^1.17.1",
+    "@opennextjs/cloudflare": "^1.19.6",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^20",
     "@types/react": "19.2.7",


### PR DESCRIPTION
## Summary

Fixes a Cloudflare Workers runtime crash (`Error 1101 / HTTP 500`) caused by Next.js 16.2's new `prefetch-hints.json` manifest not being handled by the installed `@opennextjs/cloudflare@1.17.1`.

## Root Cause

Next.js 16.2 introduced `prefetch-hints.json` as a new server manifest, loaded unconditionally by `NextNodeServer.getPrefetchHints()` during Worker initialization. The `@opennextjs/cloudflare` adapter patches `loadManifest()` at build time by globbing for `*-manifest.json` files and inlining their contents. Since `prefetch-hints.json` doesn't match the `*-manifest.json` glob pattern, no inline return was generated for it, and the Worker threw `Unexpected loadManifest(/.next/server/prefetch-hints.json) call!` on **every request**, returning HTTP 500.

This is a known issue: [opennextjs/opennextjs-cloudflare#1158](https://github.com/opennextjs/opennextjs-cloudflare/issues/1158)

**Note:** The recently added Cloudflare WAF rules (#135) are **not** the cause of the 500 errors. The WAF rules are working correctly — blocked paths return 403, and legitimate paths are passed through to the Worker. The Worker crash is entirely from this OpenNext adapter incompatibility.

## Fix

Upgrade `@opennextjs/cloudflare` from `^1.17.1` to `^1.19.6`.

The fix for `prefetch-hints.json` landed in `1.17.3` ([PR #1160](https://github.com/opennextjs/opennextjs-cloudflare/pull/1160)). Subsequent releases added further improvements for optional manifests and extensionless manifest handling ([PR #1151](https://github.com/opennextjs/opennextjs-cloudflare/pull/1151)).

### Changelog highlights relevant to this upgrade

| Version | Changes |
|---------|---------|
| `1.17.3` | Include `prefetch-hints.json` in `loadManifest` build-time inlining |
| `1.18.x` | Optional manifest fallbacks, extensionless manifest matching |
| `1.19.x` | Additional Next.js 16 support improvements, SWR implementation |

## Verification

- [x] Local `wrangler dev` returns HTTP 200 for `/`, `/blog`, `/about`
- [x] `opennextjs-cloudflare build` completes without errors
- [x] CI passes (validate-deployment-path job confirms the Cloudflare Workers build)

## Deployment

Cloudflare Pages on push to main will auto-deploy using:
```
Build: bun install && bun run scripts/generate-posts-data.ts && npx opennextjs-cloudflare build
Deploy: npx opennextjs-cloudflare deploy
```

Closes #121