### PR TITLE
docs: add Cloudflare WAF rules documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,32 @@ Contributions are welcome! Please check out my [contribution guidelines](.github
 
 ## 🔒 Security
 
+### Cloudflare WAF
+
+A [Cloudflare WAF Custom Rule](https://developers.cloudflare.com/waf/custom-rules/) blocks common reconnaissance and exploitation paths at the edge before they reach the origin server. This reduces origin load, filters access log noise, and eliminates unnecessary attack surface.
+
+**Blocked path patterns:**
+
+- Version control: `.git`, `.svn`
+- Configuration files: `.env`, `.config`, `.htaccess`, `.htpasswd`
+- Infrastructure credentials: `.aws`
+- WordPress endpoints: `wp-login`, `wp-admin`, `wp-includes`, `wp-content`, `xmlrpc`
+- Database interfaces: `phpmyadmin`
+- OS metadata: `.DS_Store`
+
+**Verification:**
+
+```bash
+# Blocked paths return HTTP 403 from Cloudflare edge
+curl -I https://stbensonimoh.com/.env
+curl -I https://stbensonimoh.com/wp-login.php
+
+# Normal paths return HTTP 200
+curl -I https://stbensonimoh.com/
+```
+
+**Monitoring:** Review blocked requests via **Security > Events** in the Cloudflare dashboard. If legitimate traffic is blocked, refine the rule with additional scoping conditions such as request method or IP allowlisting.
+
 If you discover any security-related issues, please read my [security policy](.github/SECURITY.md) for information on how to report them.
 
 ## 🌐 Deployment


### PR DESCRIPTION
## Summary

Adds documentation for the Cloudflare WAF Custom Rule deployed on `stbensonimoh.com` to the Security section of the README.

## Changes

- Added "Cloudflare WAF" subsection under `## 🔒 Security`
- Documents the 14 blocked path patterns (version control, config files, WordPress endpoints, etc.)
- Includes curl verification commands for testing blocked vs. allowed paths
- Links to Cloudflare WAF docs and monitoring guidance

## Why

Per acceptance criteria in #135, a documentation note must be added to the repo README so contributors and maintainers are aware of the active edge security rules and know how to verify and monitor them.

Closes #135