### PR TITLE
fix(a11y): hide decorative icons from screen readers

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -103,7 +103,7 @@ const Header = () => {
         onClick={toggleMenu}
         aria-label={menuOpen ? "Close menu" : "Open menu"}
       >
-        {menuOpen ? <FiX /> : <FiMenu />}
+        {menuOpen ? <FiX aria-hidden="true" /> : <FiMenu aria-hidden="true" />}
       </button>
     </>
   );

--- a/src/app/components/IconAccessibility.test.tsx
+++ b/src/app/components/IconAccessibility.test.tsx
@@ -1,0 +1,35 @@
+import { test, expect, describe } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const compDir = join(import.meta.dir);
+
+describe("Icon Accessibility", () => {
+  test("Header hamburger button icons have aria-hidden", async () => {
+    const src = await readFile(join(compDir, "Header.tsx"), "utf-8");
+    expect(src).toContain('FiX aria-hidden="true"');
+    expect(src).toContain('FiMenu aria-hidden="true"');
+  });
+
+  test("SocialIcons all have aria-hidden on icon components", async () => {
+    const src = await readFile(join(compDir, "SocialIcons.tsx"), "utf-8");
+    expect(src).toContain('FaGithub aria-hidden="true"');
+    expect(src).toContain('FaLinkedinIn aria-hidden="true"');
+    expect(src).toContain('FaXTwitter aria-hidden="true"');
+    expect(src).toContain('FaInstagram aria-hidden="true"');
+  });
+
+  test("ThemeToggle SVG icons have aria-hidden", async () => {
+    const src = await readFile(join(compDir, "ThemeToggle.tsx"), "utf-8");
+    const ariaHiddenCount = (src.match(/aria-hidden="true"/g) || []).length;
+    expect(ariaHiddenCount).toBe(3);
+  });
+
+  test("SocialIcons link elements retain their aria-label", async () => {
+    const src = await readFile(join(compDir, "SocialIcons.tsx"), "utf-8");
+    expect(src).toContain('aria-label="GitHub Profile"');
+    expect(src).toContain('aria-label="LinkedIn Profile"');
+    expect(src).toContain('aria-label="X Profile"');
+    expect(src).toContain('aria-label="Instagram Profile"');
+  });
+});

--- a/src/app/components/SocialIcons.tsx
+++ b/src/app/components/SocialIcons.tsx
@@ -16,7 +16,7 @@ const SocialIcons = (
   return (
     <div {...props} data-testid="social-icons">
       <a href={`https://github.com/${github}`} target="_blank" rel="noreferrer" aria-label="GitHub Profile" onClick={() => trackSocialClick('github')}>
-        <FaGithub />
+        <FaGithub aria-hidden="true" />
       </a>
       <a
         href={`https://linkedin.com/in/${linkedin}`}
@@ -25,7 +25,7 @@ const SocialIcons = (
         aria-label="LinkedIn Profile"
         onClick={() => trackSocialClick('linkedin')}
       >
-        <FaLinkedinIn />
+        <FaLinkedinIn aria-hidden="true" />
       </a>
       <a
         href={`https://x.com/${x}`}
@@ -34,7 +34,7 @@ const SocialIcons = (
         aria-label="X Profile"
         onClick={() => trackSocialClick('x')}
       >
-        <FaXTwitter />
+        <FaXTwitter aria-hidden="true" />
       </a>
       <a
         href={`https://instagram.com/${instagram}`}
@@ -43,7 +43,7 @@ const SocialIcons = (
         aria-label="Instagram Profile"
         onClick={() => trackSocialClick('instagram')}
       >
-        <FaInstagram />
+        <FaInstagram aria-hidden="true" />
       </a>
     </div>
   );

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -42,6 +42,7 @@ export default function ThemeToggle() {
       {theme === "system" ? (
         // Computer icon for system theme
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -58,6 +59,7 @@ export default function ThemeToggle() {
       ) : actualTheme === "light" ? (
         // Moon icon for dark mode
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
@@ -74,6 +76,7 @@ export default function ThemeToggle() {
       ) : (
         // Sun icon for light mode
         <svg
+          aria-hidden="true"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"


### PR DESCRIPTION
## Why

Icons inside elements that already have `aria-label` or text content are decorative and should be hidden from screen readers. Without `aria-hidden="true"`, screen readers announce redundant icon content alongside the accessible name.

## What Changed

- **Header.tsx**: Added `aria-hidden="true"` to `FiX` and `FiMenu` icons (button already has `aria-label`)
- **SocialIcons.tsx**: Added `aria-hidden="true"` to `FaGithub`, `FaLinkedinIn`, `FaXTwitter`, `FaInstagram` (parent `<a>` elements already have `aria-label`)
- **ThemeToggle.tsx**: Added `aria-hidden="true"` to all three SVG icons (button already has `aria-label`)

## Acceptance Criteria (Issue #93 — Task 4)
- [x] All decorative icons have `aria-hidden="true"`
- [x] Interactive elements with icons still have accessible names

## Testing
- `bun run build`: Passed
- `bun test`: 5 pass, 0 fail
- `bun run lint`: 0 errors (existing warnings only)

Closes #93 (partial — Task 4 of 5)