### PR TITLE
fix(a11y): add visible focus indicators to interactive elements

### DIFF
--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -26,7 +26,7 @@ const Button: React.FC<ButtonProps> = (props) => {
 
   if (type === "internal") {
     return (
-      <Link {...(rest as LinkProps<string>)} className={`button flex items-center border border-bensonpink w-max py-3 px-10 font-dosis uppercase text-xl font-bold text-bensonpink hover:text-white`}>
+      <Link {...(rest as LinkProps<string>)} className={`button flex items-center border border-bensonpink w-max py-3 px-10 font-dosis uppercase text-xl font-bold text-bensonpink hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2`}>
           {children}
       </Link>
     );
@@ -36,7 +36,7 @@ const Button: React.FC<ButtonProps> = (props) => {
     return (
       <a
         {...(rest as AnchorHTMLAttributes<HTMLAnchorElement>)}
-        className={`button flex items-center border border-bensonpink w-max py-3 px-10 font-dosis uppercase text-xl font-bold text-bensonpink hover:text-white`}
+        className={`button flex items-center border border-bensonpink w-max py-3 px-10 font-dosis uppercase text-xl font-bold text-bensonpink hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2`}
       >
         {children}
       </a>
@@ -46,7 +46,7 @@ const Button: React.FC<ButtonProps> = (props) => {
   return (
     <button
       {...(rest as ButtonHTMLAttributes<HTMLButtonElement>)}
-      className={`button flex items-center border border-bensonpink w-max py-3 px-10 font-dosis uppercase text-xl font-bold text-bensonpink hover:text-white`}
+      className={`button flex items-center border border-bensonpink w-max py-3 px-10 font-dosis uppercase text-xl font-bold text-bensonpink hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2`}
     >
       {children}
     </button>

--- a/src/app/components/FocusVisibility.test.tsx
+++ b/src/app/components/FocusVisibility.test.tsx
@@ -1,0 +1,31 @@
+import { test, expect, describe } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const compDir = join(import.meta.dir);
+
+describe("Focus Visibility", () => {
+  test("Button internal variant has focus-visible styles", async () => {
+    const src = await readFile(join(compDir, "Button.tsx"), "utf-8");
+    expect(src).toContain("focus-visible:outline-none");
+    expect(src).toContain("focus-visible:ring-2");
+    expect(src).toContain("focus-visible:ring-primary");
+  });
+
+  test("All three Button variants have focus-visible styles", async () => {
+    const src = await readFile(join(compDir, "Button.tsx"), "utf-8");
+    const focusCount = (src.match(/focus-visible:ring-2/g) || []).length;
+    // Three variants: internal Link, external anchor, button element
+    expect(focusCount).toBe(3);
+  });
+
+  test("tailwind.css nav links have focus-visible styles", async () => {
+    const src = await readFile(
+      join(import.meta.dir, "../tailwind.css"),
+      "utf-8"
+    );
+    expect(src).toContain("focus-visible:outline-none");
+    expect(src).toContain("focus-visible:ring-2");
+    expect(src).toContain("focus-visible:ring-primary");
+  });
+});

--- a/src/app/tailwind.css
+++ b/src/app/tailwind.css
@@ -92,7 +92,7 @@ body {
 /* GLOBAL STYLES */
 /* Header */
 .main-navigation a {
-  @apply mx-4 p-2;
+	@apply mx-4 p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary;
 }
 .active,
 .active-menu-item {


### PR DESCRIPTION
## Why

Several interactive elements had no visible focus indicator, making keyboard navigation impossible. Users who rely on keyboard can't see which element has focus.

## What Changed

- **Button.tsx**: Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2` to all three button variants (internal Link, external anchor, and button element)
- **tailwind.css**: Updated `.main-navigation a` styles to include `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary` for desktop nav links

## Acceptance Criteria (Issue #93 — Task 5)
- [x] Buttons and links have visible focus rings
- [x] Focus ring uses brand color (`--primary`)
- [x] No elements use `focus:outline-none` without a replacement

## Testing
- `bun run build`: Passed
- `bun test`: 5 pass, 0 fail
- `bun run lint`: 0 errors (existing warnings only)

Closes #93 (partial — Task 5 of 5)